### PR TITLE
BAU: Fix dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-tests/
 README.md
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/app/notification/examplar_data.py
+++ b/app/notification/examplar_data.py
@@ -1,0 +1,49 @@
+examplar_magic_link_data = {
+    "type": "MAGIC_LINK",
+    "to": "test_recipient@email.com",
+    "content": {
+        "magic_link_url": "MAGIC-LINK-GOES-HERE",
+        "fund_name": "FUND NAME GOES HERE",
+    },
+}
+
+examplar_application_data = {
+    "type": "APPLICATION_RECORD_OF_SUBMISSION",
+    "to": "example_email@test.com",
+    "content": {
+        "application": {
+            "id": "123456789",
+            "account_id": "string",
+            "status": "NOT_STARTED",
+            "fund_id": "fund-a",
+            "round_id": "summer",
+            "project_name": "Funding service",
+            "date_submitted": "2022-05-14 10:20:44",
+            "started_at": "2022-05-20 14:47:12",
+            "last_edited": None,
+            "sections": [
+                {
+                    "section_name": "about-your-org",
+                    "status": "NOT_STARTED",
+                    "questions": [
+                        {
+                            "question": "Application information",
+                            "status": "NOT STARTED",
+                            "fields": [
+                                {
+                                    "key": "application-name",
+                                    "title": "Applicant name",
+                                    "type": "text",
+                                    "answer": "Jack-Simon",
+                                },
+                            ],
+                            "category": None,
+                            "index": None,
+                        }
+                    ],
+                    "metadata": {"paymentSkipped": None},
+                }
+            ],
+        }
+    },
+}

--- a/app/notification/magic_link/map_contents.py
+++ b/app/notification/magic_link/map_contents.py
@@ -1,13 +1,6 @@
 from app.notification.model.exceptions import NotificationError
 
-examplar_magic_link_data = {
-    "type": "MAGIC_LINK",
-    "to": "test_recipient@email.com",
-    "content": {
-        "magic_link_url": "MAGIC-LINK-GOES-HERE",
-        "fund_name": "FUND NAME GOES HERE",
-    },
-}
+
 
 
 class ProcessMagicLinkData:

--- a/app/notification/magic_link/map_contents.py
+++ b/app/notification/magic_link/map_contents.py
@@ -1,5 +1,5 @@
 from app.notification.model.exceptions import NotificationError
-
+from app.notification.examplar_data import examplar_magic_link_data
 
 
 

--- a/app/notification/magic_link/map_contents.py
+++ b/app/notification/magic_link/map_contents.py
@@ -1,7 +1,13 @@
 from app.notification.model.exceptions import NotificationError
-from tests.test_magic_link.magic_link_data import (
-    expected_magic_link_data,
-)
+
+examplar_magic_link_data = {
+    "type": "MAGIC_LINK",
+    "to": "test_recipient@email.com",
+    "content": {
+        "magic_link_url": "MAGIC-LINK-GOES-HERE",
+        "fund_name": "FUND NAME GOES HERE",
+    },
+}
 
 
 class ProcessMagicLinkData:
@@ -28,6 +34,6 @@ class ProcessMagicLinkData:
                 message=(
                     "Incorrect MAGIC LINK data, please check the contents of"
                     " the MAGIC LINK data. \nExample data:"
-                    f"{expected_magic_link_data}"
+                    f"{examplar_magic_link_data}"
                 )
             )

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -6,12 +6,9 @@ from app.notification.model.exceptions import NotificationError
 from app.notification.model.notification import Notification
 from config import Config
 from notifications_python_client import NotificationsAPIClient
-from tests.test_application.application_data import (
-    expected_application_data,
-)
-from tests.test_magic_link.magic_link_data import (
-    expected_magic_link_data,
-)
+from app.notification.examplar_data import examplar_magic_link_data
+from app.notification.examplar_data import examplar_application_data
+
 
 notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
 
@@ -49,7 +46,7 @@ class Notifier:
                 message=(
                     "Incorrect MAGIC LINK data, please check the contents of"
                     " the MAGIC LINK data. \nExample data:"
-                    f" {expected_magic_link_data}"
+                    f" {examplar_magic_link_data}"
                 )
             )
 
@@ -82,7 +79,7 @@ class Notifier:
                 message=(
                     "Incorrect APPLICATION data, please check the contents of"
                     " the APPLICATION data. \nExample data:"
-                    f" {expected_application_data}"
+                    f" {examplar_application_data}"
                 )
             )
 


### PR DESCRIPTION
The dockerfile was previous failing because the app code relies on some code in the tests folder 🤯 e.g. https://github.com/communitiesuk/funding-service-design-notification/blob/c8f7fa40c28d970f648be8b3cd030169c4d3a000/app/notification/magic_link/map_contents.py#L2-L4
To fix this we need to include the tests folder in the docker image. We should also refactor to stop this referencing as it's bad practice.