### PR TITLE
FS-1677: Pass through GITHUB_SHA to app 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           cf_space:    ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push funding-service-design-notification-dev  --var GOV_NOTIFY_API_KEY=${{secrets.GOV_NOTIFY_API_KEY}}
+          command: push funding-service-design-notification-dev  --var GOV_NOTIFY_API_KEY=${{secrets.GOV_NOTIFY_API_KEY}} --var GITHUB_SHA="${{ github.sha }}"
 
   security:
     needs: deploy_dev
@@ -102,7 +102,7 @@ jobs:
           cf_space:    ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push funding-service-design-notification-test  --var GOV_NOTIFY_API_KEY=${{secrets.GOV_NOTIFY_API_KEY}}
+          command: push funding-service-design-notification-test  --var GOV_NOTIFY_API_KEY=${{secrets.GOV_NOTIFY_API_KEY}} --var GITHUB_SHA="${{ github.sha }}"
 
 # TODO reinstate performance tests once applicaiton refctoring complete
   run_performance_tests:

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,6 +12,7 @@ applications:
     GOV_NOTIFY_API_KEY: ((GOV_NOTIFY_API_KEY))
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://8092c54bdc3a4b4ba124dea42b836504@o1432034.ingest.sentry.io/4503918903820288
+    GITHUB_SHA: ((GITHUB_SHA))
   health-check-http-endpoint: /healthcheck
   health-check-type: http
 
@@ -27,6 +28,7 @@ applications:
     GOV_NOTIFY_API_KEY: ((GOV_NOTIFY_API_KEY))
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://8092c54bdc3a4b4ba124dea42b836504@o1432034.ingest.sentry.io/4503918903820288
+    GITHUB_SHA: ((GITHUB_SHA))
   health-check-http-endpoint: /healthcheck
   health-check-type: http
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,7 +98,7 @@ flask-babel==2.0.0
     #   funding-service-design-utils
 flask-talisman==0.8.1
     # via -r requirements.txt
-funding-service-design-utils==1.0.1
+funding-service-design-utils==1.0.7
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 #-----------------------------------
 #   FSD Utils
 #-----------------------------------
-funding-service-design-utils==1.0.1
+funding-service-design-utils==1.0.7
 requests
 
 #-----------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ flask-babel==2.0.0
     # via funding-service-design-utils
 flask-talisman==0.8.1
     # via -r requirements.in
-funding-service-design-utils==1.0.1
+funding-service-design-utils==1.0.7
     # via -r requirements.in
 gunicorn==20.1.0
     # via funding-service-design-utils


### PR DESCRIPTION
Implements utils feature to pass through the `GITHUB_SHA` for Sentry release

- pass through github sha to app
- bump utils version
