### PR TITLE
Removed fields strict validation

### DIFF
--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -78,7 +78,6 @@ components:
           properties:
             application:
               type: object
-              additionalProperties: true
               properties:
                 reference:
                   type: string
@@ -104,18 +103,7 @@ components:
                               type: array
                               items:
                                 type: object
-                                properties:
-                                    title:
-                                      type: string
-                                    answer:
-                                      anyOf:
-                                        - type: string
-                                        - type: array
-                                        - type: boolean
-                                        - nullable: true
-                                required:
-                                    - title
-                                    - answer
+                                additionalProperties: true
                           required:
                             - question
                             - fields

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -78,6 +78,7 @@ components:
           properties:
             application:
               type: object
+              additionalProperties: true
               properties:
                 reference:
                   type: string


### PR DESCRIPTION
- The answer validation failed due to a missing answer value not counting as nullable. 