### PR TITLE
FS 2385: Copy concurrency keys from Workflow repo Notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
 
   deploy_dev:
     if: ${{ github.actor != 'dependabot[bot]' }}
+    concurrency: deploy_dev_${{github.repository}}
     needs: testing
     runs-on: ubuntu-latest
     environment: Dev
@@ -59,6 +60,7 @@ jobs:
 
   run-shared-tests_dev:
     needs: deploy_dev
+    concurrency: run-shared-tests_dev
     if: ${{ github.actor != 'dependabot[bot]'}}
     uses: communitiesuk/funding-design-service-workflows/.github/workflows/run-shared-tests.yml@main
     with:
@@ -97,6 +99,7 @@ jobs:
 
   deploy_test:
     if: ${{ github.ref == 'refs/heads/main' }}
+    concurrency: deploy_test_${{github.repository}}
     # TODO: restore this once security check can pass, see https://communities-govuk.slack.com/archives/C02PHBER287/p1664794101631599
     # needs: security
     runs-on: ubuntu-latest
@@ -125,6 +128,7 @@ jobs:
 
   run-shared-tests_test:
     needs: deploy_test
+    concurrency: run-shared-tests_test
     if: ${{ github.actor != 'dependabot[bot]'}}
     uses: communitiesuk/funding-design-service-workflows/.github/workflows/run-shared-tests.yml@main
     with:


### PR DESCRIPTION
### Change description

Copied concurrency keys from these PRs as this repo does not use the shared workflow from the Workflows repo:
https://github.com/communitiesuk/funding-service-design-workflows/pull/43
https://github.com/communitiesuk/funding-service-design-workflows/pull/45


### How to test


N/A


### Screenshots of UI changes (if applicable)

N/A
