### PR TITLE
implement dynamic templates for submission

### DIFF
--- a/app/notification/application/map_contents.py
+++ b/app/notification/application/map_contents.py
@@ -26,9 +26,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class Application(_NotificationContents):
-    contact_info: str
     questions: bytes
-    fund_name: str
     fund_id: str
     round_name: str
     reference: str

--- a/app/notification/application/map_contents.py
+++ b/app/notification/application/map_contents.py
@@ -12,7 +12,11 @@ import pytz
 from app.notification.model.multi_input_data import MultiInput
 from app.notification.model.notification_utils import format_answer
 from app.notification.model.notification_utils import simplify_title
+from app.notification.notification_contents_base_class import (
+    _NotificationContents,
+)
 from bs4 import BeautifulSoup
+from config import Config
 from flask import current_app
 from fsd_utils.config.notify_constants import NotifyConstants
 
@@ -21,12 +25,14 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Application:
+class Application(_NotificationContents):
     contact_info: str
     questions: bytes
     fund_name: str
+    fund_id: str
     round_name: str
     reference: str
+    reply_to_email_id: str
     submission_date: str = None
 
     @property
@@ -66,8 +72,14 @@ class Application:
             questions=cls.bytes_object_for_questions_answers(notification),
             submission_date=application_data.get("date_submitted"),
             fund_name=application_data.get("fund_name"),
+            fund_id=application_data.get("fund_id"),
             round_name=application_data.get("round_name"),
             reference=application_data.get("reference"),
+            reply_to_email_id=Config.REPLY_TO_EMAILS_WITH_NOTIFY_ID[
+                notification.content.get(
+                    NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD
+                )
+            ],
         )
 
     @classmethod

--- a/app/notification/application_reminder/map_contents.py
+++ b/app/notification/application_reminder/map_contents.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from app.notification.notification_contents_base_class import (
+    _NotificationContents,
+)
 from config import Config
 from flask import current_app
 
@@ -12,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class ApplicationReminder:
+class ApplicationReminder(_NotificationContents):
     contact_info: str
     fund_name: str
     round_name: str

--- a/app/notification/application_reminder/map_contents.py
+++ b/app/notification/application_reminder/map_contents.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 @dataclass
 class ApplicationReminder(_NotificationContents):
-    contact_info: str
-    fund_name: str
     round_name: str
     reference: str
     deadline_date: str

--- a/app/notification/magic_link/map_contents.py
+++ b/app/notification/magic_link/map_contents.py
@@ -17,8 +17,6 @@ from config import Config
 
 @dataclass
 class MagicLink(_NotificationContents):
-    contact_info: str
-    fund_name: str
     magic_link: str
     request_new_link_url: str
     contact_help_email: str

--- a/app/notification/magic_link/map_contents.py
+++ b/app/notification/magic_link/map_contents.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from app.notification.notification_contents_base_class import (
+    _NotificationContents,
+)
 from flask import current_app
 from fsd_utils.config.notify_constants import NotifyConstants
 
@@ -13,7 +16,7 @@ from config import Config
 
 
 @dataclass
-class MagicLink:
+class MagicLink(_NotificationContents):
     contact_info: str
     fund_name: str
     magic_link: str

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -72,7 +72,10 @@ class Notifier:
             contents = Application.from_notification(notification)
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
-                template_id=Config.APPLICATION_RECORD_TEMPLATE_ID,
+                template_id=Config.APPLICATION_RECORD_TEMPLATE_ID[
+                    contents.fund_id
+                ]["template_id"],
+                email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,
                     "application reference": contents.reference,

--- a/app/notification/notification_contents_base_class.py
+++ b/app/notification/notification_contents_base_class.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class _NotificationContents:
+    contact_info: str
+    fund_name: str

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -22,10 +22,18 @@ class DefaultConfig:
     MAGIC_LINK_TEMPLATE_ID = os.environ.get(
         "MAGIC_LINK_TEMPLATE_ID", "02a6d48a-f227-4b9a-9dd7-9e0cf203c8a2"
     )
-    APPLICATION_RECORD_TEMPLATE_ID = os.environ.get(
-        "APPLICATION_RECORD_TEMPLATE_ID",
-        "0ddadcb3-ebe7-44f9-90e6-80ff3b61e0cb",
-    )
+
+    APPLICATION_RECORD_TEMPLATE_ID = {
+        "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4": {
+            "fund_name": "COF",
+            "template_id": "0ddadcb3-ebe7-44f9-90e6-80ff3b61e0cb",
+        },
+        "13b95669-ed98-4840-8652-d6b7a19964db": {
+            "fund_name": "NSTF",
+            "template_id": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b",
+        },
+    }
+
     INCOMPLETE_APPLICATION_TEMPLATE_ID = os.environ.get(
         "INCOMPLETE_APPLICATION_TEMPLATE_ID",
         "fc8cff7c-a595-4590-a1a4-eccda48d8604",

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -9,10 +9,13 @@ expected_application_data = {
     NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
     NotifyConstants.FIELD_TO: "test_application@example.com",
     NotifyConstants.FIELD_CONTENT: {
+        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: (
+            "COF@levellingup.gov.uk"
+        ),
         NotifyConstants.APPLICATION_FIELD: {
             "id": "123456789",
             "reference": "1564564564-56-4-54-4654",
-            "fund_id": "fund-a",
+            "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
             "round_name": "summer",
             "date_submitted": "2022-05-14T09:25:44.124542",
             "fund_name": "Community Ownership Fund",
@@ -52,7 +55,7 @@ expected_application_data = {
                     ],
                 }
             ],
-        }
+        },
     },
 }
 
@@ -60,10 +63,13 @@ expected_application_data_contains_none_answers = {
     NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
     NotifyConstants.FIELD_TO: "test_application@example.com",
     NotifyConstants.FIELD_CONTENT: {
+        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: (
+            "COF@levellingup.gov.uk"
+        ),
         NotifyConstants.APPLICATION_FIELD: {
             "id": "123456789",
             "reference": "1564564564-56-4-54-4654",
-            "fund_id": "fund-a",
+            "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
             "round_name": "summer",
             "date_submitted": "2022-05-14T14:25:44.124542",
             "fund_name": "Community Ownership Fund",
@@ -91,7 +97,7 @@ expected_application_data_contains_none_answers = {
                     ],
                 }
             ],
-        }
+        },
     },
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,4 +42,6 @@ def application_class_data():
         round_name="Round 1",
         reference="ABC123",
         submission_date="2022-05-14T09:25:44.124542",
+        fund_id="test_fund_id",
+        reply_to_email_id="test_email_address",
     )


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2871

### Change description
The Record of your application email should be displaying Night Shelter as the fund name in the Subject, Fund name, in the bottom of the email body and the reply-to email need to be made dynamic. 

During the course of this ticket, it was found that dynamic templating was not working. This has been corrected for this template and can be seen in the config files (per fund).

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
pytest


### Screenshots of UI changes (if applicable)
<img width="577" alt="image" src="https://github.com/communitiesuk/funding-service-design-notification/assets/95699325/f704d19b-a8f3-43b3-9283-c0a17c848f49">

