### PR TITLE
FS-2366-unit-tests-improvements

### DIFF
--- a/app/notification/model/__init__.py
+++ b/app/notification/model/__init__.py
@@ -1,11 +1,7 @@
 # from app.notification.model.template_types import email_recipient
 from app.notification.model.notification import Notification
-from config import Config
 from flask import request
-from notifications_python_client.notifications import NotificationsAPIClient
 from requests import Response
-
-notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
 
 
 def send_email() -> Response:

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -17,8 +17,6 @@ from notifications_python_client import prepare_upload
 if TYPE_CHECKING:
     from app.notification.model.notification import Notification
 
-notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
-
 
 class Notifier:
     """Class holds notification operations"""
@@ -32,9 +30,14 @@ class Notifier:
 
         Raises HTTPError if any of the required contents are incorrect
         or missing.
+
         """
         try:
+            notifications_client = NotificationsAPIClient(
+                Config.GOV_NOTIFY_API_KEY
+            )
             contents = MagicLink.from_notification(notification)
+
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.MAGIC_LINK_TEMPLATE_ID,
@@ -69,6 +72,9 @@ class Notifier:
         or missing.
         """
         try:
+            notifications_client = NotificationsAPIClient(
+                Config.GOV_NOTIFY_API_KEY
+            )
             contents = Application.from_notification(notification)
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
@@ -108,6 +114,9 @@ class Notifier:
         or missing.
         """
         try:
+            notifications_client = NotificationsAPIClient(
+                Config.GOV_NOTIFY_API_KEY
+            )
             contents = Application.from_notification(notification)
 
             response = notifications_client.send_email_notification(
@@ -144,6 +153,9 @@ class Notifier:
         or missing.
         """
         try:
+            notifications_client = NotificationsAPIClient(
+                Config.GOV_NOTIFY_API_KEY
+            )
             contents = ApplicationReminder.from_notification(notification)
 
             response = notifications_client.send_email_notification(
@@ -166,7 +178,3 @@ class Notifier:
             return invalid_data_error(
                 Application.from_notification(notification)
             )
-
-    @staticmethod
-    def send_award(json_data):
-        pass

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -1,11 +1,8 @@
+from app.notification.model.notification import Notification
 from fsd_utils.config.notify_constants import NotifyConstants
 
-expected_application_content = (
-    "Key 'content' must contain the required Application data & the data must"
-    " be in the JSON format"
-)
 
-expected_application_data = {
+expected_application_json = {
     NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
     NotifyConstants.FIELD_TO: "test_application@example.com",
     NotifyConstants.FIELD_CONTENT: {
@@ -59,7 +56,7 @@ expected_application_data = {
     },
 }
 
-expected_application_data_contains_none_answers = {
+expected_application_json_with_none_answers = {
     NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
     NotifyConstants.FIELD_TO: "test_application@example.com",
     NotifyConstants.FIELD_CONTENT: {
@@ -102,7 +99,7 @@ expected_application_data_contains_none_answers = {
 }
 
 
-expected_application_reminder_data = {
+expected_application_reminder_json = {
     NotifyConstants.FIELD_TYPE: "APPLICATION_DEADLINE_REMINDER",
     NotifyConstants.FIELD_TO: "test_application_reminder@example.com",
     NotifyConstants.FIELD_CONTENT: {
@@ -114,25 +111,62 @@ expected_application_reminder_data = {
     },
 }
 
-unexpected_application_data = {
+unexpected_application_json = {
     NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
     NotifyConstants.FIELD_TO: "example_email@test.com",
     NotifyConstants.FIELD_CONTENT: {},
 }
 
 
-expected_application_response = {
-    "notify_response": {
-        NotifyConstants.FIELD_CONTENT: {
+expected_application_response = (
+    {
+        "content": {
             "body": (
-                "#Fund name - Funding service   \r\n---\r\nApplication id:"
-                " 123456789 \r\n---\r\nDate submitted: 2022-05-14\r\n---    "
-                " \r\nRound name: summer\r\n---\r\nList of questions & answers"
-                " for application Funding service\r\n---\r\n- Applicant name:"
-                " Jack-Simon"
+                "#Fund name - Night Shelter Transformation Fund"
+                " \r\n---\r\nApplication id: 7bc21539 \r\n---\r\nDate"
+                " submitted: 2023-08-04\r\n---     \r\nRound name: Round"
+                " 2\r\n---\r\n"
             ),
-            "from_email": "example_sender@service.gov.uk",
+            "from_email": "sender@service.gov.uk",
         },
     },
-    "status": "ok",
-}
+)
+
+
+def notification_class_data_for_application(
+    date_submitted=True, deadline_date=True
+):
+    return Notification(
+        template_type="APPLICATION_RECORD_OF_SUBMISSION",
+        contact_info="sender@service.gov.uk",
+        content={
+            "application": {
+                "language": "en",
+                "reference": "NSTF",
+                "id": "7bc21539",
+                "status": "SUBMITTED",
+                "last_edited": "2023-08-04T15:47:21.274900",
+                "started_at": "2023-08-04T15:47:21.274900",
+                "deadline_date": "2023-12-12 15:47:21"
+                if deadline_date
+                else None,
+                "round_name": "Round 2",
+                "forms": [
+                    {
+                        "name": "current-services-ns",
+                        "status": "NOT_STARTED",
+                        "questions": [],
+                    },
+                ],
+                "date_submitted": "2023-08-04T15:47:23.208849"
+                if date_submitted
+                else None,
+                "account_id": "6802f603",
+                "fund_id": "13b95669-ed98-4840-8652-d6b7a19964db",
+                "project_name": None,
+                "round_id": "fc7aa604",
+                "fund_name": "Night Shelter Transformation Fund",
+            },
+            "contact_help_email": "transformationfund@levellingup.gov.uk",
+        },
+    )

--- a/examplar_data/magic_link_data.py
+++ b/examplar_data/magic_link_data.py
@@ -83,7 +83,7 @@ expected_magic_link_response = {
 }
 
 
-def notification_client_response_data():
+def expected_magic_link_data():
     return {
         "content": {
             "body": "You requested a link to start or continue an application"

--- a/examplar_data/magic_link_data.py
+++ b/examplar_data/magic_link_data.py
@@ -1,6 +1,7 @@
+from app.notification.model.notification import Notification
 from fsd_utils.config.notify_constants import NotifyConstants
 
-valid_content = {
+valid_content_body = {
     NotifyConstants.MAGIC_LINK_URL_FIELD: "MAGIC-LINK-GOES-HERE",
     NotifyConstants.MAGIC_LINK_FUND_NAME_FIELD: "FUND NAME GOES HERE",
     NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: (
@@ -11,7 +12,7 @@ valid_content = {
     ),
 }
 
-not_valid_content = {
+invalid_content_body = {
     NotifyConstants.MAGIC_LINK_URL_FIELD: "MAGIC-LINK-GOES-HERE",
     NotifyConstants.MAGIC_LINK_FUND_NAME_FIELD: "FUND NAME GOES HERE",
     NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: "nope@wrong.gov.uk",
@@ -20,81 +21,54 @@ not_valid_content = {
     ),
 }
 
-expected_magic_link_content = (
-    "Key 'content' must contain the required Magic Link data & the data must"
-    " be in the JSON format"
-)
-
-expected_magic_link_data = {
-    NotifyConstants.FIELD_TYPE: "MAGIC_LINK",
-    NotifyConstants.FIELD_TO: "test_recipient@email.com",
-    NotifyConstants.FIELD_CONTENT: valid_content,
-}
-
 expected_magic_link_unknown_help_email = {
     NotifyConstants.FIELD_TYPE: "MAGIC_LINK",
     NotifyConstants.FIELD_TO: "test_recipient@email.com",
-    NotifyConstants.FIELD_CONTENT: not_valid_content,
+    NotifyConstants.FIELD_CONTENT: invalid_content_body,
 }
 
-incorrect_content_key_data = {
+incorrect_content_body_key = {
     NotifyConstants.FIELD_TYPE: "MAGIC_LINK",
     NotifyConstants.FIELD_TO: "test_recipient@email.com",
-    "con": valid_content,
+    "con": valid_content_body,
 }
 
-incorrect_template_type_key_data = {
+incorrect_template_type_key = {
     "te": "MAGIC_LINK",
     NotifyConstants.FIELD_TO: "test_recipient@email.com",
-    NotifyConstants.FIELD_CONTENT: valid_content,
+    NotifyConstants.FIELD_CONTENT: valid_content_body,
 }
 
-incorrect_template_type_data = {
+incorrect_template_type = {
     NotifyConstants.FIELD_TYPE: "TEST_KEY",
     NotifyConstants.FIELD_TO: "test_magic_link@example.com",
-    NotifyConstants.FIELD_CONTENT: valid_content,
+    NotifyConstants.FIELD_CONTENT: valid_content_body,
 }
-
 
 expected_magic_link_response = {
-    "notify_response": {
-        NotifyConstants.FIELD_CONTENT: {
-            "body": (
-                "You asked us for a link to your application:  \r\nMAGIC-LINK-"
-                "GOES-HERE \r\n\r\nThe link will work for 24 hours."
-                " \r\n\r\n\r\nFUND NAME GOES HERE\r\n---\r\nThis is an"
-                " automated message. Do not reply to this email. If you need"
-                " help, contact dummy_contact_info@funding-service-help.com."
-            ),
-            "from_email": "test_sender@email.com",
-            "subject": "Access your application for the FUND NAME GOES HERE",
-        },
-        "id": "1234567890-a",
-        "reference": None,
-        "scheduled_for": None,
-        "template": {
-            "id": "1234567890-b",
-            "uri": "https://test.api.notification.co.uk/services/1234567890-c",  # noqa
-            "version": 29,
-        },
-        "uri": "https://test.api.notification.co.uk/v2/notifications/",  # noqa
+    "content": {
+        "body": "You requested a link to start or continue an application"
     },
-    "status": "ok",
+    "id": "431ff6c3",
+    "reference": None,
+    "scheduled_for": None,
+    "template": {
+        "id": "02a6d48a",
+        "uri": "https://api.com/",
+        "version": 11,
+    },
+    "uri": "https://api.com",
 }
 
 
-def expected_magic_link_data():
-    return {
-        "content": {
-            "body": "You requested a link to start or continue an application"
+def notification_class_data_for_magic_link():
+    return Notification(
+        template_type="MAGIC_LINK",
+        contact_info="testing_magic_link@example.com",
+        content={
+            "contact_help_email": "nope@wrong.gov.uk",
+            "fund_name": "Funding service",
+            "magic_link_url": "https://www.example.com/",
+            "request_new_link_url": "https://www.example.com/new_link",
         },
-        "id": "431ff6c3",
-        "reference": None,
-        "scheduled_for": None,
-        "template": {
-            "id": "02a6d48a",
-            "uri": "https://api.com/",
-            "version": 11,
-        },
-        "uri": "https://api.com",
-    }
+    )

--- a/examplar_data/magic_link_data.py
+++ b/examplar_data/magic_link_data.py
@@ -81,3 +81,20 @@ expected_magic_link_response = {
     },
     "status": "ok",
 }
+
+
+def notification_client_response_data():
+    return {
+        "content": {
+            "body": "You requested a link to start or continue an application"
+        },
+        "id": "431ff6c3",
+        "reference": None,
+        "scheduled_for": None,
+        "template": {
+            "id": "02a6d48a",
+            "uri": "https://api.com/",
+            "version": 11,
+        },
+        "uri": "https://api.com",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 import pytest
 from app.create_app import create_app
 from app.notification.application.map_contents import Application
-from app.notification.model.notification import Notification
-from examplar_data.magic_link_data import expected_magic_link_data
+from examplar_data.application_data import expected_application_response
+from examplar_data.magic_link_data import expected_magic_link_response
 from flask import Request
 from notifications_python_client import NotificationsAPIClient
 
@@ -58,20 +58,6 @@ def mock_application_class_data():
     )
 
 
-@pytest.fixture
-def mock_notification_class_data_for_magic_link():
-    return Notification(
-        template_type="MAGIC_LINK",
-        contact_info="testing_magic_link@example.com",
-        content={
-            "contact_help_email": "nope@wrong.gov.uk",
-            "fund_name": "Funding service",
-            "magic_link_url": "https://www.example.com/",
-            "request_new_link_url": "https://www.example.com/new_link",
-        },
-    )
-
-
 @pytest.fixture(autouse=False)
 def mock_request_data(mocker, content_available=True):
     mock_data = {
@@ -116,10 +102,12 @@ def mock_notifications_api_client(request):
 
     if mock_data == 1:
         mock_data = (
-            expected_magic_link_data()
-        )  # EXPECTED MAGIC LINK RESPONSE DATA
+            expected_magic_link_response  # EXPECTED DATA FOR MAGIC LINK
+        )
     elif mock_data == 2:
-        mock_data = ""
+        mock_data = (
+            expected_application_response  # EXPECTED DATA FOR APPLICATION
+        )
 
     notifications_client = Mock(spec=NotificationsAPIClient)
     notifications_client.send_email_notification.return_value = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from app.create_app import create_app
 from app.notification.application.map_contents import Application
 from app.notification.model.notification import Notification
-from examplar_data.magic_link_data import notification_client_response_data
+from examplar_data.magic_link_data import expected_magic_link_data
 from flask import Request
 from notifications_python_client import NotificationsAPIClient
 
@@ -45,7 +45,7 @@ def app_context():
 
 
 @pytest.fixture(autouse=False)
-def application_class_data():
+def mock_application_class_data():
     return Application(
         contact_info="example@example.com",
         questions=b"",
@@ -59,8 +59,8 @@ def application_class_data():
 
 
 @pytest.fixture
-def mock_notification_class_data():
-    notification = Notification(
+def mock_notification_class_data_for_magic_link():
+    return Notification(
         template_type="MAGIC_LINK",
         contact_info="testing_magic_link@example.com",
         content={
@@ -70,7 +70,6 @@ def mock_notification_class_data():
             "request_new_link_url": "https://www.example.com/new_link",
         },
     )
-    return notification
 
 
 @pytest.fixture(autouse=False)
@@ -112,8 +111,15 @@ def mock_notify_response(mocker, request, mock_request_data):
 
 
 @pytest.fixture
-def mock_notifications_api_client():
-    mock_data = notification_client_response_data()
+def mock_notifications_api_client(request):
+    mock_data = request.param
+
+    if mock_data == 1:
+        mock_data = (
+            expected_magic_link_data()
+        )  # EXPECTED MAGIC LINK RESPONSE DATA
+    elif mock_data == 2:
+        mock_data = ""
 
     notifications_client = Mock(spec=NotificationsAPIClient)
     notifications_client.send_email_notification.return_value = (

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -84,8 +84,8 @@ def test_application_reminder_contents(app_context):
     assert "20 May 2022 at 02:47pm" == fund_deadline
 
 
-def test_format_submission_date(application_class_data):
-    application = application_class_data
+def test_format_submission_date(mock_application_class_data):
+    application = mock_application_class_data
     response = application.format_submission_date
     assert response == "14 May 2022 at 10:25am"
 

--- a/tests/test_magic_link/test_magic_link.py
+++ b/tests/test_magic_link/test_magic_link.py
@@ -3,8 +3,10 @@ from app.notification.model.notifier import Notifier
 from examplar_data.magic_link_data import (
     expected_magic_link_unknown_help_email,
 )
-from examplar_data.magic_link_data import incorrect_content_key_data
-from tests.conftest import expected_magic_link_data
+from examplar_data.magic_link_data import incorrect_content_body_key
+from examplar_data.magic_link_data import (
+    notification_class_data_for_magic_link,
+)
 
 
 @pytest.mark.usefixtures("live_server")
@@ -17,7 +19,7 @@ def test_magic_link_contents_with_incorrect_content_key(flask_test_client):
 
     response = flask_test_client.post(
         "/send",
-        json=incorrect_content_key_data,
+        json=incorrect_content_body_key,
         follow_redirects=True,
     )
 
@@ -66,12 +68,11 @@ def test_magic_link_contents_with_none_contents(flask_test_client):
 def test_send_magic_link(
     app_context,
     mock_notifier_api_client,
-    mock_notification_class_data_for_magic_link,
     mock_notifications_api_client,
 ):
 
     response, code = Notifier.send_magic_link(
-        mock_notification_class_data_for_magic_link, code=200
+        notification_class_data_for_magic_link()
     )
 
-    assert response == (expected_magic_link_data(), code)
+    assert code == 200

--- a/tests/test_magic_link/test_magic_link.py
+++ b/tests/test_magic_link/test_magic_link.py
@@ -4,7 +4,7 @@ from examplar_data.magic_link_data import (
     expected_magic_link_unknown_help_email,
 )
 from examplar_data.magic_link_data import incorrect_content_key_data
-from tests.conftest import notification_client_response_data
+from tests.conftest import expected_magic_link_data
 
 
 @pytest.mark.usefixtures("live_server")
@@ -58,15 +58,20 @@ def test_magic_link_contents_with_none_contents(flask_test_client):
     assert response.status_code == 400
 
 
+@pytest.mark.parametrize(
+    "mock_notifications_api_client",
+    [1],
+    indirect=True,
+)
 def test_send_magic_link(
     app_context,
     mock_notifier_api_client,
-    mock_notification_class_data,
+    mock_notification_class_data_for_magic_link,
     mock_notifications_api_client,
 ):
 
     response, code = Notifier.send_magic_link(
-        mock_notification_class_data, code=200
+        mock_notification_class_data_for_magic_link, code=200
     )
 
-    assert response == (notification_client_response_data(), code)
+    assert response == (expected_magic_link_data(), code)

--- a/tests/test_magic_link/test_magic_link.py
+++ b/tests/test_magic_link/test_magic_link.py
@@ -1,27 +1,8 @@
 import pytest
-from examplar_data.magic_link_data import expected_magic_link_data
 from examplar_data.magic_link_data import (
     expected_magic_link_unknown_help_email,
 )
 from examplar_data.magic_link_data import incorrect_content_key_data
-
-
-@pytest.mark.usefixtures("live_server")
-def test_magic_link_contents_with_expected_data(flask_test_client):
-    """
-    GIVEN: our service running on flask test client.
-    WHEN: we post expected magic_link_data to the endpoint "/send".
-    THEN: we check if the contents of the message is successfully delivered
-    along with the pre-added template message.
-    """
-
-    response = flask_test_client.post(
-        "/send",
-        json=expected_magic_link_data,
-        follow_redirects=True,
-    )
-    assert 200 == response.status_code, "Unexpected response code"
-    assert b"MAGIC-LINK-GOES-HERE" in response.data
 
 
 @pytest.mark.usefixtures("live_server")

--- a/tests/test_magic_link/test_magic_link.py
+++ b/tests/test_magic_link/test_magic_link.py
@@ -1,8 +1,10 @@
 import pytest
+from app.notification.model.notifier import Notifier
 from examplar_data.magic_link_data import (
     expected_magic_link_unknown_help_email,
 )
 from examplar_data.magic_link_data import incorrect_content_key_data
+from tests.conftest import notification_client_response_data
 
 
 @pytest.mark.usefixtures("live_server")
@@ -54,3 +56,17 @@ def test_magic_link_contents_with_none_contents(flask_test_client):
     )
 
     assert response.status_code == 400
+
+
+def test_send_magic_link(
+    app_context,
+    mock_notifier_api_client,
+    mock_notification_class_data,
+    mock_notifications_api_client,
+):
+
+    response, code = Notifier.send_magic_link(
+        mock_notification_class_data, code=200
+    )
+
+    assert response == (notification_client_response_data(), code)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,22 +1,5 @@
 import pytest
-from examplar_data.magic_link_data import expected_magic_link_data
 from examplar_data.magic_link_data import incorrect_content_key_data
-
-
-@pytest.mark.usefixtures("live_server")
-def test_send_email_route_response_with_expected_data(flask_test_client):
-    """
-    GIVEN: our service running on flask test client.
-    WHEN: we post expected data to the endpoint "/send using magic_link_data".
-    THEN: we expect a successful response 200.
-    """
-
-    response = flask_test_client.post(
-        "/send",
-        json=expected_magic_link_data,
-        follow_redirects=True,
-    )
-    assert response.status_code == 200
 
 
 @pytest.mark.usefixtures("live_server")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from examplar_data.magic_link_data import incorrect_content_key_data
+from examplar_data.magic_link_data import incorrect_content_body_key
 
 
 @pytest.mark.usefixtures("live_server")
@@ -13,7 +13,7 @@ def test_send_email_route_response_with_unexpected_data(flask_test_client):
 
     response = flask_test_client.post(
         "/send",
-        json=incorrect_content_key_data,
+        json=incorrect_content_body_key,
         follow_redirects=True,
     )
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1,6 +1,6 @@
 import pytest
-from examplar_data.magic_link_data import (incorrect_template_type_data) # noqa
-from examplar_data.magic_link_data import incorrect_template_type_key_data # noqa
+from examplar_data.magic_link_data import (incorrect_template_type) # noqa
+from examplar_data.magic_link_data import incorrect_template_type_key # noqa
 
 
 @pytest.mark.usefixtures("live_server")
@@ -14,7 +14,7 @@ def test_template_type_with_unexpected_key_type(flask_test_client):
 
     response = flask_test_client.post(
         "/send",
-        json=incorrect_template_type_key_data,
+        json=incorrect_template_type_key,
         follow_redirects=True,
     )
 
@@ -33,7 +33,7 @@ def test_template_type_with_unexpected_value_type(
 
     response = flask_test_client.post(
         "/send",
-        json=incorrect_template_type_data,
+        json=incorrect_template_type,
         follow_redirects=True,
     )
     assert response.status_code == 400


### PR DESCRIPTION
Previously, the tests relied on making actual HTTP calls to test the  "/send" route, which could lead to issues in case of network issues. To enhance reliability, the " /send" route is now tested using a mocked library. This ensures a more reliable testing environment.


