### PR TITLE
Fs 3441 Added yelp hook for secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,7 @@ repos:
       - id: reorder-python-imports
         name: Reorder Python imports (src, tests)
         args: ["--application-directories", "src"]
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+    -   id: detect-secrets

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Then run:
     https://docs.notifications.service.gov.uk/python.html#api-keys
 
     Set it as an environment variable e.g.
-    `export GOV_NOTIFY_API_KEY="api-key-value"`
+    ```
+    // pragma: allowlist secret
+    export GOV_NOTIFY_API_KEY="api-key-value
+    ```
 
     Note: For unit (integration) testing, you also need to set this in `pytest.ini`
 

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -8,7 +8,7 @@ from fsd_utils import configclass
 @configclass
 class DevConfig(Config):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
 
     # Logging

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -7,7 +7,7 @@ from fsd_utils import configclass
 @configclass
 class DevelopmentConfig(DefaultConfig):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
     FLASK_ENV = "development"
 

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -8,7 +8,7 @@ from fsd_utils import configclass
 class UnitTestConfig(DefaultConfig):
 
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
 
     # Logging

--- a/copilot/environments/addons/funding-service-magic-links.yml
+++ b/copilot/environments/addons/funding-service-magic-links.yml
@@ -88,6 +88,6 @@ Outputs:
     Value:
       !Sub
       - "rediss://:${PASSWORD}@${HOSTNAME}:${PORT}"
-      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]
+      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]  # pragma: allowlist secret
         HOSTNAME: !GetAtt 'Redis.RedisEndpoint.Address'
         PORT: !GetAtt 'Redis.RedisEndpoint.Port'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def mock_notifications_api_client(request):
 
 @pytest.fixture
 def mock_notifier_api_client(mock_notifications_api_client):
-    mock_api_key = "MOCK_API_KEY"
+    mock_api_key = "MOCK_API_KEY"  # pragma: allowlist secret
     with patch(
         "app.notification.model.notifier.NotificationsAPIClient",
         return_value=mock_notifications_api_client,


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Change description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugin `HexHighEntropyString` which tend to detect lot of false positives

### How to test
- Add a secret/API/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 