### PR TITLE
BAU - Move the permissions to the job call

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -47,42 +47,62 @@ jobs:
     with:
       postgres_unit_testing: false
 
-  copilot_deploy_dev:
+  dev_copilot_deploy:
     if: inputs.environment == 'dev' || inputs.environment == ''
     needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-dev
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: ./.github/workflows/environment.yml
     with:
       workspace: 'dev'
 
-  copilot_deploy_test:
+  test_copilot_deploy:
     if: inputs.environment == 'test' || inputs.environment == ''
     needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-test
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: ./.github/workflows/environment.yml
     with:
       workspace: 'test'
 
   # Allow the capability to override UAT with another branch, but ideally uat and production should be in sync as much as possible
-  copilot_deploy_uat:
+  uat_copilot_deploy:
     if: inputs.environment == 'uat' || inputs.environment == ''
     needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-uat
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: ./.github/workflows/environment.yml
     with:
       workspace: 'uat'
 
   # Only run this if the branch being deployed is main
-  copilot_deploy_production:
+  production_copilot_deploy:
     if: (inputs.environment == 'production' || inputs.environment == '') && github.ref == 'refs/heads/main'
     needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-production
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: ./.github/workflows/environment.yml
     with:
       workspace: 'production'
 
   post_deploy_tests:
-      needs: copilot_deploy_test
+      needs: test_copilot_deploy
       secrets:
         E2E_PAT: ${{secrets.E2E_PAT}}
       uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -6,11 +6,12 @@ on:
         required: true
         type: string
 
+    secrets:
+      AWS_ACCOUNT:
+        required: true
+
 jobs:
   copilot_deploy:
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read  # This is required for actions/checkout
     runs-on: ubuntu-latest
     environment: ${{ inputs.workspace }}
     steps:


### PR DESCRIPTION
### Change description
* Moving the id-token and content permissions to the job call, not the contents of the job
* Passing secret through to sub-job

+ref: BAU
+semver: minor

- [N/A] Unit tests and other appropriate tests added or updated
- [N/A] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")