### PR TITLE
BAU Remove E2E PAT token

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -46,7 +46,6 @@ jobs:
 
   pre_deploy_tests:
     secrets:
-      E2E_PAT: ${{ secrets.E2E_PAT }}
       GOV_NOTIFY_API_KEY: ${{ secrets.GOV_NOTIFY_API_KEY }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/pre-deploy.yml@main
     with:


### PR DESCRIPTION
### Change description
Remove the no-longer-needed E2E PAT token

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")