### PR TITLE
Move production to prod due to certificate name length restrictions

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -10,7 +10,7 @@ on:
         - dev
         - test
         - uat
-        - production
+        - prod
       run_performance_tests:
         required: false
         default: false
@@ -75,7 +75,7 @@ jobs:
             echo "env_list=[\"${{ inputs.environment }}\"]" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" == 'refs/heads/main' ]; then
             echo "pre_deploy_list=[\"dev\", \"test\"]" >> $GITHUB_OUTPUT
-            echo "post_deploy_list=[\"uat\", \"production\"]" >> $GITHUB_OUTPUT
+            echo "post_deploy_list=[\"uat\", \"prod\"]" >> $GITHUB_OUTPUT
           else
             echo "pre_deploy_list=[\"dev\", \"test\"]" >> $GITHUB_OUTPUT
           fi
@@ -341,17 +341,17 @@ jobs:
       run_e2e_tests: ${{ inputs.run_e2e_tests || true }}
       environment: uat
 
-  production_deploy:
+  prod_deploy:
     if: ${{ needs.copilot_environments_workflow_setup.outputs.post_matrix != '' && toJson(fromJson(needs.copilot_environments_workflow_setup.outputs.post_matrix)) != '[]' }}
     concurrency:
-      group: 'fsd-preaward-copilot-production'
+      group: 'fsd-preaward-copilot-prod'
       cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
     needs: [ tag_version, post_uat_deploy_tests, paketo_build, copilot_environments_workflow_setup ]
     runs-on: ubuntu-latest
-    environment: production
+    environment: prod
     steps:
     - name: Git clone the repository
       uses: actions/checkout@v4
@@ -376,7 +376,7 @@ jobs:
     - name: confirm copilot env
       shell: bash
       run: |
-        if [ $(copilot env ls) != "production" ]; then
+        if [ $(copilot env ls) != "prod" ]; then
           echo $(copilot env ls)
           exit 1
         fi
@@ -389,7 +389,7 @@ jobs:
       run: |
         yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-notification:${{ github.ref_name == 'main' && 'latest' || needs.tag_version.outputs.version_to_tag }}"'  copilot/fsd-notification/manifest.yml
 
-    - name: Copilot production deploy
+    - name: Copilot prod deploy
       id: deploy_build
       run: |
-        copilot svc deploy --env production --app pre-award
+        copilot svc deploy --env prod --app pre-award

--- a/copilot/fsd-notification/manifest.yml
+++ b/copilot/fsd-notification/manifest.yml
@@ -76,7 +76,7 @@ environments:
         value: 80
       requests: 30
       response_time: 2s
-  production:
+  prod:
     count:
       range: 2-4
       cooldown:
@@ -87,3 +87,5 @@ environments:
       memory_percentage:
         value: 80
       requests: 30
+    variables:
+      FLASK_ENV: production


### PR DESCRIPTION
### Change description
Use prod as the environment name rather than prod.  Leave alone the configuration used by FLASK_ENV.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

