### PR TITLE
BAU Remove continue-on-error

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -90,7 +90,6 @@ jobs:
       contents: read  # This is required for actions/checkout
     needs: [ tag_version, pre_deploy_tests, paketo_build, copilot_environments_workflow_setup ]
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       max-parallel: 1
       matrix:
@@ -283,7 +282,6 @@ jobs:
       contents: read  # This is required for actions/checkout
     needs: [ tag_version, post_test_deploy_tests, paketo_build, copilot_environments_workflow_setup ]
     runs-on: ubuntu-latest
-    continue-on-error: true
     environment: uat
     steps:
     - name: Git clone the repository


### PR DESCRIPTION
# Description

We don't want to continue the workflow beyond any deploy that fails.

