### PR TITLE
FS-4192: Welsh translations for EOI

### DIFF
--- a/app/notification/application/map_contents.py
+++ b/app/notification/application/map_contents.py
@@ -29,6 +29,7 @@ class Application(_NotificationContents):
     reply_to_email_id: str
     submission_date: str = None
     caveats: str = None
+    language: str = None
 
     @property
     def format_submission_date(self):
@@ -74,6 +75,7 @@ class Application(_NotificationContents):
             fund_id=application_data.get("fund_id"),
             round_name=application_data.get("round_name"),
             reference=application_data.get("reference"),
+            language=application_data.get("language"),
             reply_to_email_id=Config.REPLY_TO_EMAILS_WITH_NOTIFY_ID[
                 notification.content.get(
                     NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -122,7 +122,7 @@ class Notifier:
                 email_address=contents.contact_info,
                 template_id=Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[
                     contents.fund_id
-                ][template_name]["template_id"],
+                ][template_name]["template_id"].get(contents.language, "en"),
                 email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -29,11 +29,17 @@ class DefaultConfig:
         "54c11ec2-0b16-46bb-80d2-f210e47a8791": {
             NotifyConstants.TEMPLATE_TYPE_EOI_PASS: {
                 "fund_name": "COF",
-                "template_id": "04db42f4-a74e-4ab3-b9e2-565592fd6f46",
+                "template_id": {
+                    "en": "04db42f4-a74e-4ab3-b9e2-565592fd6f46",
+                    "cy": "46915152-ee11-4bce-a0e1-ce1033078640",
+                },
             },
             NotifyConstants.TEMPLATE_TYPE_EOI_PASS_W_CAVEATS: {
                 "fund_name": "COF",
-                "template_id": "705684c7-6985-4d4c-9170-08a85f47b8e1",
+                "template_id": {
+                    "en": "705684c7-6985-4d4c-9170-08a85f47b8e1",
+                    "cy": "ead6bfc2-f3a1-468c-8d5a-87a32bf31311",
+                },
             },
         },
     }

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -149,7 +149,7 @@ expected_eoi_application_response = (
 
 
 def notification_class_data_for_application(
-    date_submitted=True, deadline_date=True
+    date_submitted=True, deadline_date=True, language="en"
 ):
     return Notification(
         template_type="APPLICATION_RECORD_OF_SUBMISSION",
@@ -157,7 +157,7 @@ def notification_class_data_for_application(
         contact_name="Test User",
         content={
             "application": {
-                "language": "en",
+                "language": language,
                 "reference": "NSTF",
                 "id": "7bc21539",
                 "status": "SUBMITTED",
@@ -188,14 +188,16 @@ def notification_class_data_for_application(
     )
 
 
-def notification_class_data_for_eoi(date_submitted=True, deadline_date=True):
+def notification_class_data_for_eoi(
+    date_submitted=True, deadline_date=True, language="en"
+):
     return Notification(
         template_type="APPLICATION_RECORD_OF_SUBMISSION",
         contact_info="sender@service.gov.uk",
         contact_name="Test User",
         content={
             "application": {
-                "language": "en",
+                "language": language,
                 "reference": "EOI",
                 "id": "7bc21539",
                 "status": "SUBMITTED",

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import ANY
 
 import pytest
 from app.notification.application.map_contents import Application
@@ -141,20 +142,34 @@ def test_send_submitted_application(
 
 
 @pytest.mark.parametrize(
-    "mock_notifications_api_client",
-    [3],
-    indirect=True,
+    "mock_notifications_api_client, language, template_id",
+    [
+        (3, "en", "705684c7-6985-4d4c-9170-08a85f47b8e1"),
+        (3, "cy", "ead6bfc2-f3a1-468c-8d5a-87a32bf31311"),
+    ],
+    indirect=["mock_notifications_api_client"],
 )
 def test_send_submitted_eoi(
     app_context,
     mock_notifier_api_client,
     mock_notifications_api_client,
+    language,
+    template_id,
 ):
     _, code = Notifier.send_submitted_eoi(
         notification=notification_class_data_for_eoi(
-            date_submitted=True, deadline_date=False
+            date_submitted=True,
+            deadline_date=False,
+            language=language,
         ),
         template_name="Pass with caveats",
+    )
+
+    mock_notifications_api_client.send_email_notification.assert_called_with(
+        email_address=ANY,
+        template_id=template_id,
+        email_reply_to_id=ANY,
+        personalisation=ANY,
     )
 
     assert code == 200


### PR DESCRIPTION
### Change description

- Add language concept for EOI emails, with 2 new templates for Welsh
- Translated templates added to govuk notify, ids are put in config

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines 
