### PR TITLE
 reverse dependabot-pip-swagger-ui-bundle-1.1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -370,7 +370,7 @@ sqlalchemy-utils==0.41.1
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-swagger-ui-bundle==1.1.0
+swagger-ui-bundle==0.0.9
     # via -r requirements.txt
 thrift==0.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -211,7 +211,7 @@ sqlalchemy==2.0.15
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.1
     # via funding-service-design-utils
-swagger-ui-bundle==1.1.0
+swagger-ui-bundle==0.0.9
     # via -r requirements.in
 thrift==0.16.0
     # via flipper-client


### PR DESCRIPTION
The swagger-bundle to release from 0.0.9 to 1.1.0 has been reversed.

In older versions of Connexion, this line  have been used to configure the base URL for accessing the Swagger documentation. By setting swagger_url to "/" (the root path), you would instruct Connexion to serve the Swagger documentation at the root URL of your application (usually http://localhost:5000/).


