### PR TITLE
FS-4287: When application is submitted and need to send an email we no longer send whole form instead generate base64encoded file with formatted file that compatible for gov notify 

### DIFF
--- a/app/notification/application/map_contents.py
+++ b/app/notification/application/map_contents.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 import pytz
 from flask import current_app
-from fsd_utils import extract_questions_and_answers
-from fsd_utils import generate_text_of_application
 from fsd_utils.config.notify_constants import NotifyConstants
 
 from app.notification.notification_contents_base_class import _NotificationContents
@@ -20,7 +18,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class Application(_NotificationContents):
-    questions: BytesIO
+    questions: str
     fund_id: str
     round_name: str
     reference: str
@@ -57,7 +55,7 @@ class Application(_NotificationContents):
         return cls(
             contact_info=notification.contact_info,
             contact_name=notification.contact_name,
-            questions=cls.bytes_object_for_questions_answers(notification),
+            questions=application_data.get("questions_file"),
             submission_date=application_data.get("date_submitted"),
             fund_name=application_data.get("fund_name"),
             fund_id=application_data.get("fund_id"),
@@ -69,46 +67,3 @@ class Application(_NotificationContents):
             ],
             caveats=caveats,
         )
-
-    @classmethod
-    def get_forms(cls, notification: Notification) -> list:
-        forms = notification.content[NotifyConstants.APPLICATION_FIELD][NotifyConstants.APPLICATION_FORMS_FIELD]
-        return forms
-
-    @classmethod
-    def get_questions_and_answers(cls, notification: Notification) -> dict:
-        """
-        Extracts questions and answers from form data.
-
-        Args:
-            notification (Notification): The form data containing the questions and answers.
-
-        Returns:
-            dict: A dictionary mapping form names to their respective questions and answers.
-        """
-        forms = cls.get_forms(notification)
-
-        questions_answers = extract_questions_and_answers(forms, notification.content["application"]["language"])
-        return questions_answers
-
-    @classmethod
-    def get_fund_name(cls, notification):
-        metadata = notification.content[NotifyConstants.APPLICATION_FIELD]
-        fund_name = metadata.get("fund_name")
-        return f"{fund_name} {round_name}" if (round_name := metadata.get("round_name")) else fund_name
-
-    @classmethod
-    def bytes_object_for_questions_answers(
-        cls,
-        notification: Notification,
-    ) -> BytesIO:
-        """Function creates a memory object for question & answers
-        with ByteIO from StringIO.
-        """
-        q_and_a = cls.get_questions_and_answers(notification)
-        fund_name = cls.get_fund_name(notification)
-        language = notification.content["application"]["language"]
-        stringIO_data = generate_text_of_application(q_and_a, fund_name, language)
-        convert_to_bytes = bytes(stringIO_data, "utf-8")
-        bytes_object = BytesIO(convert_to_bytes)
-        return bytes_object

--- a/app/notification/application/map_contents.py
+++ b/app/notification/application/map_contents.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from io import BytesIO
 from typing import TYPE_CHECKING
 
 import pytz

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from flask import current_app
 from notifications_python_client import NotificationsAPIClient
 from notifications_python_client import errors
-from notifications_python_client import prepare_upload
 
 from app.notification.application.map_contents import Application
 from app.notification.application_reminder.map_contents import ApplicationReminder

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -74,7 +74,12 @@ class Notifier:
                     "application reference": contents.reference,
                     "date submitted": contents.format_submission_date,
                     "round name": contents.round_name,
-                    "question": prepare_upload(contents.questions),
+                    "question": {
+                        "file": contents.questions,
+                        "filename": None,
+                        "confirm_email_before_download": None,
+                        "retention_period": None,
+                    },
                 },
             )
             current_app.logger.info("Call made to govuk Notify API")
@@ -108,7 +113,12 @@ class Notifier:
                     "application reference": contents.reference,
                     "date submitted": contents.format_submission_date,
                     "round name": contents.round_name,
-                    "question": prepare_upload(contents.questions),
+                    "question": {
+                        "file": contents.questions,
+                        "filename": None,
+                        "confirm_email_before_download": None,
+                        "retention_period": None,
+                    },
                     "caveats": contents.caveats,
                     "full name": contents.contact_name,
                 },
@@ -142,7 +152,12 @@ class Notifier:
                     "name of fund": contents.fund_name,
                     "application reference": contents.reference,
                     "round name": contents.round_name,
-                    "question": prepare_upload(contents.questions),
+                    "question": {
+                        "file": contents.questions,
+                        "filename": None,
+                        "confirm_email_before_download": None,
+                        "retention_period": None,
+                    },
                 },
             )
             current_app.logger.info("Call made to govuk Notify API")

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -2,100 +2,6 @@ from fsd_utils.config.notify_constants import NotifyConstants
 
 from app.notification.model.notification import Notification
 
-expected_application_json = {
-    NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
-    NotifyConstants.FIELD_TO: "test_application@example.com",
-    NotifyConstants.FIELD_CONTENT: {
-        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: ("COF@levellingup.gov.uk"),
-        NotifyConstants.APPLICATION_FIELD: {
-            "id": "123456789",
-            "reference": "1564564564-56-4-54-4654",
-            "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
-            "round_name": "summer",
-            "date_submitted": "2022-05-14T09:25:44.124542",
-            "fund_name": "Community Ownership Fund",
-            "language": "en",
-            NotifyConstants.APPLICATION_FORMS_FIELD: [
-                {
-                    NotifyConstants.APPLICATION_NAME_FIELD: "about-your-org",
-                    NotifyConstants.APPLICATION_QUESTIONS_FIELD: [
-                        {
-                            "question": "Application information",
-                            "fields": [
-                                {
-                                    "key": "application-name",
-                                    "title": "Applicant name",
-                                    "type": "text",
-                                    "answer": "Jack-Simon",
-                                },
-                                {
-                                    "key": "upload-file",
-                                    "title": "Upload file",
-                                    "type": "file",
-                                    "answer": "012ba4c7-e4971/test-one_two.three/programmer.jpeg",  # noqa
-                                },
-                                {
-                                    "key": "boolean-question-1",
-                                    "title": "Boolean Question 1 ",
-                                    "type": "list",
-                                    "answer": False,
-                                },
-                                {
-                                    "key": "boolean-question-2",
-                                    "title": "Boolean Question 2",
-                                    "type": "list",
-                                    "answer": True,
-                                },
-                            ],
-                        }
-                    ],
-                }
-            ],
-        },
-    },
-}
-
-expected_application_json_with_none_answers = {
-    NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
-    NotifyConstants.FIELD_TO: "test_application@example.com",
-    NotifyConstants.FIELD_CONTENT: {
-        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: ("COF@levellingup.gov.uk"),
-        NotifyConstants.APPLICATION_FIELD: {
-            "id": "123456789",
-            "reference": "1564564564-56-4-54-4654",
-            "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
-            "round_name": "summer",
-            "date_submitted": "2022-05-14T14:25:44.124542",
-            "fund_name": "Community Ownership Fund",
-            NotifyConstants.APPLICATION_FORMS_FIELD: [
-                {
-                    NotifyConstants.APPLICATION_NAME_FIELD: "about-your-org",
-                    NotifyConstants.APPLICATION_QUESTIONS_FIELD: [
-                        {
-                            "question": "Application information",
-                            "fields": [
-                                {
-                                    "key": "application-name",
-                                    "title": "Applicant name",
-                                    "type": "text",
-                                    "answer": None,
-                                },
-                                {
-                                    "key": "upload-file",
-                                    "title": "Upload file",
-                                    "type": "file",
-                                    "answer": None,  # noqa
-                                },
-                            ],
-                        }
-                    ],
-                }
-            ],
-        },
-    },
-}
-
-
 expected_application_reminder_json = {
     NotifyConstants.FIELD_TYPE: "APPLICATION_DEADLINE_REMINDER",
     NotifyConstants.FIELD_TO: "test_application_reminder@example.com",
@@ -114,7 +20,6 @@ unexpected_application_json = {
     NotifyConstants.FIELD_TO: "example_email@test.com",
     NotifyConstants.FIELD_CONTENT: {},
 }
-
 
 expected_application_response = (
     {

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -3,11 +3,9 @@ from unittest.mock import ANY
 
 import pytest
 
-from app.notification.application.map_contents import Application
 from app.notification.application_reminder.map_contents import ApplicationReminder
 from app.notification.model.notification import Notification
 from app.notification.model.notifier import Notifier
-from examplar_data.application_data import expected_application_json
 from examplar_data.application_data import expected_application_reminder_json
 from examplar_data.application_data import notification_class_data_for_application
 from examplar_data.application_data import notification_class_data_for_eoi
@@ -47,24 +45,6 @@ def test_application_contents_with_none_contents(flask_test_client):
     )
 
     assert response.status_code == 400
-
-
-def test_application_map_contents_response(app_context):
-    """
-    GIVEN: our service running with app_context fixture.
-    WHEN: two separate methods on different classes chained together with given
-     expected incoming JSON.
-    THEN: we check if expected output is returned.
-    """
-
-    expected_json = expected_application_json
-    data = Notification.from_json(expected_json)
-    application_class_object = Application.from_notification(data)
-    questions = application_class_object.questions
-
-    assert "Jack-Simon" in questions.getvalue().decode()
-    assert "Yes" in questions.getvalue().decode()
-    assert "No" in questions.getvalue().decode()
 
 
 def test_application_reminder_contents(app_context):


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-4287


### Change description
When application is submitted and need to send an email we no longer send whole form instead generate base64encoded file with formatted file that compatible for gov notify

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
