### PR TITLE
Update COF support email to communities from levellingup

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -103,7 +103,7 @@ class DefaultConfig:
 
     # E.G. "EMAIL": "GOV_NOTIFY_ID"
     REPLY_TO_EMAILS_WITH_NOTIFY_ID = {
-        "COF@levellingup.gov.uk": "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
+        "COF@communities.gov.uk": "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
         "transformationfund@levellingup.gov.uk": "25286d9a-8543-41b5-a00f-331b999e51f0",
         "cyprfund@levellingup.gov.uk": "72bb79a8-2748-4404-9f01-14690bee3843",
         "digitalplanningteam@levellingup.gov.uk": "73eecbb1-5dbc-4653-8c58-46aa79151210",

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -16,7 +16,7 @@ class UnitTestConfig(DefaultConfig):
 
     REPLY_TO_EMAILS_WITH_NOTIFY_ID = {
         "nope@wrong.gov.uk": "100",
-        "COF@levellingup.gov.uk": "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
+        "COF@communities.gov.uk": "10668b8d-9472-4ce8-ae07-4fcc7bf93a9d",
         "transformationfund@levellingup.gov.uk": ("25286d9a-8543-41b5-a00f-331b999e51f0"),
     }
 

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -10,7 +10,7 @@ expected_application_reminder_json = {
             "round_name": "WINDOW 2 ROUND 2",
             "reference": "WUHJFDWJ",
             "deadline_date": "2022-05-20T14:47:12",
-            "contact_help_email": "COF@levellingup.gov.uk",
+            "contact_help_email": "COF@communities.gov.uk",
         }
     },
 }

--- a/examplar_data/magic_link_data.py
+++ b/examplar_data/magic_link_data.py
@@ -5,7 +5,7 @@ from app.notification.model.notification import Notification
 valid_content_body = {
     NotifyConstants.MAGIC_LINK_URL_FIELD: "MAGIC-LINK-GOES-HERE",
     NotifyConstants.MAGIC_LINK_FUND_NAME_FIELD: "FUND NAME GOES HERE",
-    NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: ("COF@levellingup.gov.uk"),
+    NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: ("COF@communities.gov.uk"),
     NotifyConstants.MAGIC_LINK_REQUEST_NEW_LINK_URL_FIELD: ("NEW LINK URL GOES HERE"),
 }
 

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -30,7 +30,7 @@ paths:
                 "magic_link_url": "https://www.example.com/",
                 "fund_name": "Funding service",
                 "request_new_link_url": "https://www.example.com/new_link",
-                "contact_help_email": "COF@levellingup.gov.uk"
+                "contact_help_email": "COF@communities.gov.uk"
               }
       responses:
         200:


### PR DESCRIPTION


### Change description
The old COF support email was using the levellingup domain ( [cof@levellingup.gov.uk](mailto:cof@levellingup.gov.uk) ). This has been updated to the communities domain ( [cof@communities.gov.uk](mailto:cof@communities.gov.uk) )

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
