### PR TITLE
FS-3850: Application submit email template for Welsh

### DIFF
--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -67,7 +67,9 @@ class Notifier:
             contents = Application.from_notification(notification)
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
-                template_id=Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"],
+                template_id=Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"].get(
+                    contents.language, "en"
+                ),
                 email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -42,7 +42,10 @@ class DefaultConfig:
     APPLICATION_RECORD_TEMPLATE_ID = {
         "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4": {
             "fund_name": "COF",
-            "template_id": "0ddadcb3-ebe7-44f9-90e6-80ff3b61e0cb",
+            "template_id": {
+                "en": "0ddadcb3-ebe7-44f9-90e6-80ff3b61e0cb",
+                "cy": "8ffc87bc-16d8-4273-82bf-c06bdf0cf047",
+            },
         },
         "13b95669-ed98-4840-8652-d6b7a19964db": {
             "fund_name": "NSTF",

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -84,6 +84,40 @@ def notification_class_data_for_application(date_submitted=True, deadline_date=T
     )
 
 
+def notification_class_data_for_cof_application(date_submitted=True, deadline_date=True, language="en"):
+    return Notification(
+        template_type="APPLICATION_RECORD_OF_SUBMISSION",
+        contact_info="sender@service.gov.uk",
+        contact_name="Test User",
+        content={
+            "application": {
+                "language": language,
+                "reference": "COF",
+                "id": "7bc21539",
+                "status": "SUBMITTED",
+                "last_edited": "2023-08-04T15:47:21.274900",
+                "started_at": "2023-08-04T15:47:21.274900",
+                "deadline_date": ("2023-12-12T15:47:21" if deadline_date else None),
+                "round_name": "Round 4",
+                "forms": [
+                    {
+                        "name": "current-services-cof",
+                        "status": "NOT_STARTED",
+                        "questions": [],
+                    },
+                ],
+                "date_submitted": ("2023-08-04T15:47:23.208849" if date_submitted else None),
+                "account_id": "6802f603",
+                "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+                "project_name": None,
+                "round_id": "fc7aa604",
+                "fund_name": "Community Ownership Fund",
+            },
+            "contact_help_email": "transformationfund@levellingup.gov.uk",
+        },
+    )
+
+
 def notification_class_data_for_eoi(date_submitted=True, deadline_date=True, language="en"):
     return Notification(
         template_type="APPLICATION_RECORD_OF_SUBMISSION",

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -58,7 +58,7 @@ def notification_class_data_for_application(date_submitted=True, deadline_date=T
         content={
             "application": {
                 "language": language,
-                "reference": "NSTF",
+                "reference": "COF",
                 "id": "7bc21539",
                 "status": "SUBMITTED",
                 "last_edited": "2023-08-04T15:47:21.274900",
@@ -74,7 +74,7 @@ def notification_class_data_for_application(date_submitted=True, deadline_date=T
                 ],
                 "date_submitted": ("2023-08-04T15:47:23.208849" if date_submitted else None),
                 "account_id": "6802f603",
-                "fund_id": "13b95669-ed98-4840-8652-d6b7a19964db",
+                "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
                 "project_name": None,
                 "round_id": "fc7aa604",
                 "fund_name": "Night Shelter Transformation Fund",

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -8,6 +8,7 @@ from app.notification.model.notification import Notification
 from app.notification.model.notifier import Notifier
 from examplar_data.application_data import expected_application_reminder_json
 from examplar_data.application_data import notification_class_data_for_application
+from examplar_data.application_data import notification_class_data_for_cof_application
 from examplar_data.application_data import notification_class_data_for_eoi
 from examplar_data.application_data import unexpected_application_json
 
@@ -104,6 +105,39 @@ def test_send_submitted_application(
 ):
     _, code = Notifier.send_submitted_application(
         notification_class_data_for_application(date_submitted=True, deadline_date=False)
+    )
+
+    assert code == 200
+
+
+@pytest.mark.parametrize(
+    "mock_notifications_api_client, language, template_id",
+    [
+        (2, "en", "0ddadcb3-ebe7-44f9-90e6-80ff3b61e0cb"),
+        (2, "cy", "06098445-3630-47cb-b00a-3c5e939f70b3"),
+    ],
+    indirect=["mock_notifications_api_client"],
+)
+def test_send_submitted_lang(
+    app_context,
+    mock_notifier_api_client,
+    mock_notifications_api_client,
+    language,
+    template_id,
+):
+    _, code = Notifier.send_submitted_application(
+        notification=notification_class_data_for_cof_application(
+            date_submitted=True,
+            deadline_date=False,
+            language=language,
+        )
+    )
+
+    mock_notifications_api_client.send_email_notification.assert_called_with(
+        email_address=ANY,
+        template_id=template_id,
+        email_reply_to_id=ANY,
+        personalisation=ANY,
     )
 
     assert code == 200

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -114,7 +114,7 @@ def test_send_submitted_application(
     "mock_notifications_api_client, language, template_id",
     [
         (2, "en", "0ddadcb3-ebe7-44f9-90e6-80ff3b61e0cb"),
-        (2, "cy", "06098445-3630-47cb-b00a-3c5e939f70b3"),
+        (2, "cy", "8ffc87bc-16d8-4273-82bf-c06bdf0cf047"),
     ],
     indirect=["mock_notifications_api_client"],
 )


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FS-3850

### Change description
- New notify template created APPLICATION_RECORD_OF_SUBMISSION (Welsh) for application submitted in Welsh
- Changes made to use template based on language set in the application

- [X] Unit tests and other appropriate tests added or updated
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Select Welsh language, create a new COF application, complete and submit the application, validate that the email sent to the user upon submission is in Welsh and contains correct Welsh translations

### Screenshots of UI changes (if applicable)
