### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,7 +2,7 @@
 black
 debugpy
 deepdiff
-pre-commit
+pre-commit~=4.0.0
 pytest
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,9 +98,7 @@ commonmark==0.9.1
     #   -r requirements.txt
     #   rich
 connexion[flask,swagger-ui,uvicorn]==3.1.0
-    # via
-    #   -r requirements.txt
-    #   connexion
+    # via -r requirements.txt
 cryptography==43.0.0
     # via
     #   -r requirements.txt
@@ -131,7 +129,6 @@ flask[async]==3.0.3
     # via
     #   -r requirements.txt
     #   connexion
-    #   flask
     #   flask-babel
     #   flask-migrate
     #   flask-redis
@@ -247,9 +244,7 @@ markupsafe==2.1.5
 mccabe==0.7.0
     # via flake8
 moto[s3,sqs]==5.0.10
-    # via
-    #   -r requirements-dev.in
-    #   moto
+    # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.9.1
@@ -288,7 +283,7 @@ pluggy==1.5.0
     # via pytest
 prance==23.6.21.0
     # via -r requirements.txt
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements-dev.in
 py-partiql-parser==0.5.5
     # via moto
@@ -309,7 +304,6 @@ pyjwt[crypto]==2.9.0
     #   -r requirements.txt
     #   funding-service-design-utils
     #   notifications-python-client
-    #   pyjwt
 pyproject-hooks==1.1.0
     # via
     #   build
@@ -411,7 +405,6 @@ sentry-sdk[flask]==2.12.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-    #   sentry-sdk
 six==1.16.0
     # via
     #   -r requirements.txt
@@ -480,7 +473,6 @@ uvicorn[standard]==0.30.5
     # via
     #   -r requirements.txt
     #   connexion
-    #   uvicorn
 uvloop==0.19.0
     # via
     #   -r requirements.txt


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.