### PR TITLE
Adding notification related logs and adding same structure for all the funds for few email templates 

### DIFF
--- a/app/notification/model/notification.py
+++ b/app/notification/model/notification.py
@@ -94,4 +94,4 @@ class Notification:
 
         except Exception as e:
             current_app.logger.error("An exception occurred while selecting email template to send", e)
-            raise KeyError("An exception occurred while selecting email template to send")
+            raise Exception("An error occurred while selecting email template to send") from e

--- a/app/notification/model/notification.py
+++ b/app/notification/model/notification.py
@@ -40,53 +40,58 @@ class Notification:
         Function matches with the correct template type &
         calls the relevant function.
         """
-        notification = Notification.from_json(json_data)
-        match json_data.get("type"):
-            case NotifyConstants.TEMPLATE_TYPE_MAGIC_LINK:
-                current_app.logger.info(f"Validating template type: {notification.template_type}")
-                return Notifier.send_magic_link(notification)
+        try:
+            notification = Notification.from_json(json_data)
+            match json_data.get("type"):
+                case NotifyConstants.TEMPLATE_TYPE_MAGIC_LINK:
+                    current_app.logger.info(f"Validating template type: {notification.template_type}")
+                    return Notifier.send_magic_link(notification)
 
-            case NotifyConstants.TEMPLATE_TYPE_APPLICATION:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_submitted_application(notification)
+                case NotifyConstants.TEMPLATE_TYPE_APPLICATION:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_submitted_application(notification)
 
-            case NotifyConstants.TEMPLATE_TYPE_INCOMPLETE_APPLICATION:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_incomplete_application(notification)
+                case NotifyConstants.TEMPLATE_TYPE_INCOMPLETE_APPLICATION:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_incomplete_application(notification)
 
-            case NotifyConstants.TEMPLATE_TYPE_REMINDER:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_application_reminder(notification)
+                case NotifyConstants.TEMPLATE_TYPE_REMINDER:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_application_reminder(notification)
 
-            case NotifyConstants.TEMPLATE_TYPE_EOI_PASS:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_submitted_eoi(
-                    notification=notification,
-                    template_name=NotifyConstants.TEMPLATE_TYPE_EOI_PASS,
-                )
+                case NotifyConstants.TEMPLATE_TYPE_EOI_PASS:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_submitted_eoi(
+                        notification=notification,
+                        template_name=NotifyConstants.TEMPLATE_TYPE_EOI_PASS,
+                    )
 
-            case NotifyConstants.TEMPLATE_TYPE_EOI_PASS_W_CAVEATS:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_submitted_eoi(
-                    notification=notification,
-                    template_name=NotifyConstants.TEMPLATE_TYPE_EOI_PASS_W_CAVEATS,
-                )
+                case NotifyConstants.TEMPLATE_TYPE_EOI_PASS_W_CAVEATS:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_submitted_eoi(
+                        notification=notification,
+                        template_name=NotifyConstants.TEMPLATE_TYPE_EOI_PASS_W_CAVEATS,
+                    )
 
-            case NotifyConstants.TEMPLATE_TYPE_ASSESSMENT_APPLICATION_ASSIGNED:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_assessment_assigned(
-                    notification=notification,
-                )
+                case NotifyConstants.TEMPLATE_TYPE_ASSESSMENT_APPLICATION_ASSIGNED:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_assessment_assigned(
+                        notification=notification,
+                    )
 
-            case NotifyConstants.TEMPLATE_TYPE_ASSESSMENT_APPLICATION_UNASSIGNED:
-                current_app.logger.info(f"Validating template type: {notification.template_type})")
-                return Notifier.send_assessment_unassigned(
-                    notification=notification,
-                )
+                case NotifyConstants.TEMPLATE_TYPE_ASSESSMENT_APPLICATION_UNASSIGNED:
+                    current_app.logger.info(f"Validating template type: {notification.template_type})")
+                    return Notifier.send_assessment_unassigned(
+                        notification=notification,
+                    )
 
-            case "NOTIFICATION" | "AWARD":
-                return f"Currently {notification.template_type} service is not available."  # noqa
+                case "NOTIFICATION" | "AWARD":
+                    return f"Currently {notification.template_type} service is not available."  # noqa
 
-            case _:
-                current_app.logger.exception(f"Incorrect template type {notification.template_type}")
-                return template_type_error(json_data)
+                case _:
+                    current_app.logger.exception(f"Incorrect template type {notification.template_type}")
+                    return template_type_error(json_data)
+
+        except Exception as e:
+            current_app.logger.error("An exception occurred while selecting email template to send", e)
+            raise KeyError("An exception occurred while selecting email template to send")

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -35,7 +35,7 @@ class Notifier:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = MagicLink.from_notification(notification)
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.MAGIC_LINK_TEMPLATE_ID}")
+                f"Getting template id {Config.MAGIC_LINK_TEMPLATE_ID}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.MAGIC_LINK_TEMPLATE_ID,
@@ -189,7 +189,7 @@ class Notifier:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = ApplicationReminder.from_notification(notification)
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID}")
+                f"Getting template id {Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID,
@@ -214,7 +214,7 @@ class Notifier:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Assignment.from_notification(notification)
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.ASSESSMENT_APPLICATION_ASSIGNED}")
+                f"Getting template id {Config.ASSESSMENT_APPLICATION_ASSIGNED}")
             # Note that this uses the default Notify account reply-to unless we specify otherwise
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
@@ -241,7 +241,7 @@ class Notifier:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Assignment.from_notification(notification)
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.ASSESSMENT_APPLICATION_UNASSIGNED}")
+                f"Getting template id {Config.ASSESSMENT_APPLICATION_UNASSIGNED}")
             # Note that this uses the default Notify account reply-to unless we specify otherwise
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -66,12 +66,11 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
-            template_id = Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"]
-            current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {template_id}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
-                template_id= template_id.get(contents.language, "en") if isinstance(template_id, dict) else template_id,
+                template_id=Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"].get(
+                    contents.language, "en"
+                ),
                 email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,
@@ -106,12 +105,11 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
-            template_id = Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id]["template_id"]
-            current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {template_id}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
-                template_id=template_id.get(contents.language, "en") if isinstance(template_id, dict) else template_id,
+                template_id=Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id][template_name][
+                    "template_id"
+                ].get(contents.language, "en"),
                 email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -66,13 +66,12 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
+            template_id = Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"]
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]['template_id']}")
+                f"Getting template for fund id [{contents.fund_id}] and template id {template_id}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
-                template_id=Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"].get(
-                    contents.language, "en"
-                ),
+                template_id= template_id.get(contents.language, "en") if isinstance(template_id, dict) else template_id,
                 email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,
@@ -107,13 +106,12 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
+            template_id = Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id]["template_id"]
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id][template_name]['template_id']}")
+                f"Getting template for fund id [{contents.fund_id}] and template id {template_id}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
-                template_id=Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id][template_name][
-                    "template_id"
-                ].get(contents.language, "en"),
+                template_id=template_id.get(contents.language, "en") if isinstance(template_id, dict) else template_id,
                 email_reply_to_id=contents.reply_to_email_id,
                 personalisation={
                     "name of fund": contents.fund_name,

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -34,7 +34,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = MagicLink.from_notification(notification)
-
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.MAGIC_LINK_TEMPLATE_ID}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.MAGIC_LINK_TEMPLATE_ID,
@@ -65,6 +66,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]['template_id']}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.APPLICATION_RECORD_TEMPLATE_ID[contents.fund_id]["template_id"].get(
@@ -104,6 +107,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id][template_name]['template_id']}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.EXPRESSION_OF_INTEREST_TEMPLATE_ID[contents.fund_id][template_name][
@@ -145,7 +150,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
-
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.INCOMPLETE_APPLICATION_TEMPLATE_ID[contents.fund_id]['template_id']}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 email_reply_to_id=contents.reply_to_email_id,
@@ -182,7 +188,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = ApplicationReminder.from_notification(notification)
-
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID,
@@ -206,7 +213,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Assignment.from_notification(notification)
-
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.ASSESSMENT_APPLICATION_ASSIGNED}")
             # Note that this uses the default Notify account reply-to unless we specify otherwise
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
@@ -232,7 +240,8 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Assignment.from_notification(notification)
-
+            current_app.logger.info(
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.ASSESSMENT_APPLICATION_UNASSIGNED}")
             # Note that this uses the default Notify account reply-to unless we specify otherwise
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -34,8 +34,7 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = MagicLink.from_notification(notification)
-            current_app.logger.info(
-                f"Getting template id {Config.MAGIC_LINK_TEMPLATE_ID}")
+            current_app.logger.info(f"Getting template id {Config.MAGIC_LINK_TEMPLATE_ID}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.MAGIC_LINK_TEMPLATE_ID,
@@ -147,7 +146,8 @@ class Notifier:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.INCOMPLETE_APPLICATION_TEMPLATE_ID[contents.fund_id]['template_id']}")
+                f"Getting template for fund id [{contents.fund_id}] and template id {Config.INCOMPLETE_APPLICATION_TEMPLATE_ID[contents.fund_id]['template_id']}"
+            )
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 email_reply_to_id=contents.reply_to_email_id,
@@ -184,8 +184,7 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = ApplicationReminder.from_notification(notification)
-            current_app.logger.info(
-                f"Getting template id {Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID}")
+            current_app.logger.info(f"Getting template id {Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID}")
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
                 template_id=Config.APPLICATION_DEADLINE_REMINDER_TEMPLATE_ID,
@@ -209,8 +208,7 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Assignment.from_notification(notification)
-            current_app.logger.info(
-                f"Getting template id {Config.ASSESSMENT_APPLICATION_ASSIGNED}")
+            current_app.logger.info(f"Getting template id {Config.ASSESSMENT_APPLICATION_ASSIGNED}")
             # Note that this uses the default Notify account reply-to unless we specify otherwise
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,
@@ -236,8 +234,7 @@ class Notifier:
         try:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Assignment.from_notification(notification)
-            current_app.logger.info(
-                f"Getting template id {Config.ASSESSMENT_APPLICATION_UNASSIGNED}")
+            current_app.logger.info(f"Getting template id {Config.ASSESSMENT_APPLICATION_UNASSIGNED}")
             # Note that this uses the default Notify account reply-to unless we specify otherwise
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -146,7 +146,8 @@ class Notifier:
             notifications_client = NotificationsAPIClient(Config.GOV_NOTIFY_API_KEY)
             contents = Application.from_notification(notification)
             current_app.logger.info(
-                f"Getting template for fund id [{contents.fund_id}] and template id {Config.INCOMPLETE_APPLICATION_TEMPLATE_ID[contents.fund_id]['template_id']}"
+                f"Getting template for fund id [{contents.fund_id}] "
+                f"and template id {Config.INCOMPLETE_APPLICATION_TEMPLATE_ID[contents.fund_id]['template_id']}"
             )
             response = notifications_client.send_email_notification(
                 email_address=contents.contact_info,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -72,19 +72,31 @@ class DefaultConfig:
         },
         "13b95669-ed98-4840-8652-d6b7a19964db": {
             "fund_name": "NSTF",
-            "template_id": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b",
+            "template_id": {
+                "en": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b",
+                "cy": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b"
+            },
         },
         "1baa0f68-4e0a-4b02-9dfe-b5646f089e65": {
             "fund_name": "CYP",
-            "template_id": "1c69f104-edfa-49d7-9bab-cbbd30c323f3",
+            "template_id": {
+                "en": "1c69f104-edfa-49d7-9bab-cbbd30c323f3",
+                "cy": "1c69f104-edfa-49d7-9bab-cbbd30c323f3"
+            },
         },
         "f493d512-5eb4-11ee-8c99-0242ac120002": {
             "fund_name": "DPI",
-            "template_id": "6e1d80ac-c843-4b47-9946-ecad542dd5de",
+            "template_id": {
+                "en": "6e1d80ac-c843-4b47-9946-ecad542dd5de",
+                "cy": "6e1d80ac-c843-4b47-9946-ecad542dd5de"
+            },
         },
         "1e4bd8b0-b399-466d-bbd1-572171bbc7bd": {
             "fund_name": "HSRA",
-            "template_id": "52decdde-e796-4b16-a1a0-5f56c9a61b0f",
+            "template_id": {
+                "en": "52decdde-e796-4b16-a1a0-5f56c9a61b0f",
+                "cy": "52decdde-e796-4b16-a1a0-5f56c9a61b0f"
+            },
         },
     }
 

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -72,31 +72,19 @@ class DefaultConfig:
         },
         "13b95669-ed98-4840-8652-d6b7a19964db": {
             "fund_name": "NSTF",
-            "template_id": {
-                "en": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b",
-                "cy": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b"
-            },
+            "template_id": {"en": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b", "cy": "487c62f1-9aeb-4cc2-b996-5bdf0d02854b"},
         },
         "1baa0f68-4e0a-4b02-9dfe-b5646f089e65": {
             "fund_name": "CYP",
-            "template_id": {
-                "en": "1c69f104-edfa-49d7-9bab-cbbd30c323f3",
-                "cy": "1c69f104-edfa-49d7-9bab-cbbd30c323f3"
-            },
+            "template_id": {"en": "1c69f104-edfa-49d7-9bab-cbbd30c323f3", "cy": "1c69f104-edfa-49d7-9bab-cbbd30c323f3"},
         },
         "f493d512-5eb4-11ee-8c99-0242ac120002": {
             "fund_name": "DPI",
-            "template_id": {
-                "en": "6e1d80ac-c843-4b47-9946-ecad542dd5de",
-                "cy": "6e1d80ac-c843-4b47-9946-ecad542dd5de"
-            },
+            "template_id": {"en": "6e1d80ac-c843-4b47-9946-ecad542dd5de", "cy": "6e1d80ac-c843-4b47-9946-ecad542dd5de"},
         },
         "1e4bd8b0-b399-466d-bbd1-572171bbc7bd": {
             "fund_name": "HSRA",
-            "template_id": {
-                "en": "52decdde-e796-4b16-a1a0-5f56c9a61b0f",
-                "cy": "52decdde-e796-4b16-a1a0-5f56c9a61b0f"
-            },
+            "template_id": {"en": "52decdde-e796-4b16-a1a0-5f56c9a61b0f", "cy": "52decdde-e796-4b16-a1a0-5f56c9a61b0f"},
         },
     }
 


### PR DESCRIPTION
Here added try catch to handle errors while calling the gov notify and logging & raising a an error also added same structure for  APPLICATION_RECORD_TEMPLATE_ID and now when submitted an application it will use the given language or by default it will get en
