### PR TITLE
changing local log level to info

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -13,4 +13,4 @@ class DevelopmentConfig(DefaultConfig):
     FLASK_ENV = "development"
 
     # Logging
-    FSD_LOG_LEVEL = logging.DEBUG
+    FSD_LOG_LEVEL = logging.INFO


### PR DESCRIPTION
Changing the development log level to info so that the logs for docker runner stop constantly scrolling