### PR TITLE
Allow assigning our own reference to Notify emails

### DIFF
--- a/app/notification/model/notification.py
+++ b/app/notification/model/notification.py
@@ -13,6 +13,7 @@ class Notification:
     contact_info: str
     contact_name: str
     content: dict
+    govuk_notify_reference: str | None
 
     @staticmethod
     def from_json(data: dict):
@@ -26,6 +27,7 @@ class Notification:
             contact_info=data.get("to"),
             contact_name=data.get("full_name", ""),
             content=data.get("content"),
+            govuk_notify_reference=data.get("govuk_notify_reference"),
         )
         current_app.logger.info(
             f"Notification data template_type: ({notification_data.template_type}) "

--- a/app/notification/model/notifier.py
+++ b/app/notification/model/notifier.py
@@ -46,6 +46,7 @@ class Notifier:
                     "request new link url": contents.request_new_link_url,
                     "contact details": contents.contact_help_email,
                 },
+                reference=notification.govuk_notify_reference,
             )
             current_app.logger.info("Call made to govuk Notify API")
             return response, code
@@ -74,6 +75,7 @@ class Notifier:
             )
             notify_payload = {
                 "email_address": contents.contact_info,
+                "reference": notification.govuk_notify_reference,
                 "template_id": template_id,
                 "email_reply_to_id": contents.reply_to_email_id,
                 "personalisation": {
@@ -92,6 +94,7 @@ class Notifier:
                 },
             }
             response = notifications_client.send_email_notification(**notify_payload)
+            current_app.logger.info("Call made to govuk Notify API")
             return response, 200
 
         except errors.HTTPError as e:
@@ -131,6 +134,7 @@ class Notifier:
                     "caveats": contents.caveats,
                     "full name": contents.contact_name,
                 },
+                reference=notification.govuk_notify_reference,
             )
             current_app.logger.info("Call made to govuk Notify API")
             return response, code
@@ -171,6 +175,7 @@ class Notifier:
                     },
                     "contact email": notification.content.get(NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD),
                 },
+                reference=notification.govuk_notify_reference,
             )
             return response, code
 
@@ -202,6 +207,7 @@ class Notifier:
                     "round name": contents.round_name,
                     "application deadline": contents.deadline_date,
                 },
+                reference=notification.govuk_notify_reference,
             )
             current_app.logger.info("Call made to govuk Notify API")
             return response, code
@@ -228,6 +234,7 @@ class Notifier:
                     "assessment link": contents.assessment_link,
                     "lead assessor email": contents.lead_assessor_email,
                 },
+                reference=notification.govuk_notify_reference,
             )
             current_app.logger.info("Call made to govuk Notify API")
             return response, code
@@ -254,6 +261,7 @@ class Notifier:
                     "assessment link": contents.assessment_link,
                     "lead assessor email": contents.lead_assessor_email,
                 },
+                reference=notification.govuk_notify_reference,
             )
             current_app.logger.info("Call made to govuk Notify API")
             return response, code

--- a/examplar_data/application_data.py
+++ b/examplar_data/application_data.py
@@ -50,11 +50,14 @@ expected_eoi_application_response = (
 )
 
 
-def notification_class_data_for_application(date_submitted=True, deadline_date=True, language="en"):
+def notification_class_data_for_application(
+    date_submitted=True, deadline_date=True, language="en", govuk_notify_reference=None
+):
     return Notification(
         template_type="APPLICATION_RECORD_OF_SUBMISSION",
         contact_info="sender@service.gov.uk",
         contact_name="Test User",
+        govuk_notify_reference=govuk_notify_reference,
         content={
             "application": {
                 "language": language,
@@ -84,11 +87,14 @@ def notification_class_data_for_application(date_submitted=True, deadline_date=T
     )
 
 
-def notification_class_data_for_cof_application(date_submitted=True, deadline_date=True, language="en"):
+def notification_class_data_for_cof_application(
+    date_submitted=True, deadline_date=True, language="en", govuk_notify_reference=None
+):
     return Notification(
         template_type="APPLICATION_RECORD_OF_SUBMISSION",
         contact_info="sender@service.gov.uk",
         contact_name="Test User",
+        govuk_notify_reference=govuk_notify_reference,
         content={
             "application": {
                 "language": language,
@@ -118,11 +124,14 @@ def notification_class_data_for_cof_application(date_submitted=True, deadline_da
     )
 
 
-def notification_class_data_for_eoi(date_submitted=True, deadline_date=True, language="en"):
+def notification_class_data_for_eoi(
+    date_submitted=True, deadline_date=True, language="en", govuk_notify_reference=None
+):
     return Notification(
         template_type="APPLICATION_RECORD_OF_SUBMISSION",
         contact_info="sender@service.gov.uk",
         contact_name="Test User",
+        govuk_notify_reference=govuk_notify_reference,
         content={
             "application": {
                 "language": language,

--- a/examplar_data/magic_link_data.py
+++ b/examplar_data/magic_link_data.py
@@ -54,7 +54,7 @@ expected_magic_link_response = {
 }
 
 
-def notification_class_data_for_magic_link():
+def notification_class_data_for_magic_link(govuk_notify_reference=None):
     return Notification(
         template_type="MAGIC_LINK",
         contact_info="testing_magic_link@example.com",
@@ -65,4 +65,5 @@ def notification_class_data_for_magic_link():
             "magic_link_url": "https://www.example.com/",
             "request_new_link_url": "https://www.example.com/new_link",
         },
+        govuk_notify_reference=govuk_notify_reference,
     )

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -139,6 +139,7 @@ def test_send_submitted_lang(
         template_id=template_id,
         email_reply_to_id=ANY,
         personalisation=ANY,
+        reference=None,
     )
 
     assert code == 200
@@ -164,6 +165,7 @@ def test_send_submitted_eoi(
             date_submitted=True,
             deadline_date=False,
             language=language,
+            govuk_notify_reference="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
         ),
         template_name="Pass with caveats",
     )
@@ -173,6 +175,7 @@ def test_send_submitted_eoi(
         template_id=template_id,
         email_reply_to_id=ANY,
         personalisation=ANY,
+        reference="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     )
 
     assert code == 200


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-137

### Change description
Our end-to-end test suite is currently taking quite a long time to run, as many of the tests run sequentially. The main reason for needing them to run sequentially is that some tests login as the same user, and the login attempts are in conflict. This conflict is not handled well by the end-to-end tests and concurrent logins are not well supported by authenticator. Authenticator allows multiple login sessions to exist at once, but does not allow multiple unredeemed magic links to exist for one account at the same time. Furthermore, the end-to-end tests use a "list all magic links" endpoint on authenticator and then grab the top magic link off the stack. This link isn't necessarily associated with the account that they are trying to log in as, which is bad.

This patch allows a reference to be associated with an email sent via GOV.UK Notify. When a magic link email is sent, the calling code can set a reference which the e2e tests can then scan for. This will let the e2e tests retrieve the _correct_ magic link from Notify for the account it was trying to log into.