### PR TITLE
Pull image_location from paketo_build step

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -62,7 +62,7 @@ jobs:
     with:
       environment: dev
       app_name: notification
-      version: sha-${{ github.sha }}
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_dev_deploy_tests:
     needs: dev_deploy
@@ -92,7 +92,7 @@ jobs:
     with:
       environment: test
       app_name: notification
-      version: sha-${{ github.sha }}
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_test_deploy_tests:
     needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, paketo_build, setup ]
@@ -123,7 +123,7 @@ jobs:
     with:
       environment: uat
       app_name: notification
-      version: sha-${{ github.sha }}
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
 
   post_uat_deploy_tests:
     needs: [ dev_deploy, post_dev_deploy_tests, test_deploy, post_test_deploy_tests, uat_deploy, paketo_build, setup ]
@@ -154,4 +154,4 @@ jobs:
     with:
       environment: prod
       app_name: notification
-      version: sha-${{ github.sha }}
+      image_location: ${{ needs.paketo_build.outputs.image_location }}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-154

https://github.com/communitiesuk/funding-service-design-workflows/pull/215
started to output the paketo image URI, so we can now reuse that rather
than passing fragments into the deploy steps which are used to rebuild
the image URI manually. This will reduce problems with the image URI
potentially going out of sync, and allow it to be used for eg database
migrations.