### PR TITLE
Bump fsd-utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "connexion[flask,swagger-ui,uvicorn]==3.1.0",
     "flask-talisman==1.1.0",
     "flask==3.0.3",
-    "funding-service-design-utils==5.0.8",
+    "funding-service-design-utils==6.0.1",
     "notifications-python-client==10.0.0",
     "openapi-spec-validator==0.7.1",
     "prance==23.6.21.0",

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ requires-dist = [
     { name = "connexion", extras = ["flask", "swagger-ui", "uvicorn"], specifier = "==3.1.0" },
     { name = "flask", specifier = "==3.0.3" },
     { name = "flask-talisman", specifier = "==1.1.0" },
-    { name = "funding-service-design-utils", specifier = "==5.0.8" },
+    { name = "funding-service-design-utils", specifier = "==6.0.1" },
     { name = "notifications-python-client", specifier = "==10.0.0" },
     { name = "openapi-spec-validator", specifier = "==0.7.1" },
     { name = "prance", specifier = "==23.6.21.0" },
@@ -582,7 +582,7 @@ dev = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "5.0.8"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -603,9 +603,9 @@ dependencies = [
     { name = "sentry-sdk", extra = ["flask"] },
     { name = "sqlalchemy-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/54/051e40877eaf86a80763aa635c212bc26d5b6b59893f297851124e181613/funding_service_design_utils-5.0.8.tar.gz", hash = "sha256:a7c0c0acf4031f375f0cfc4974b2fa4ba10e68fcea7e5a38b50a88c407916e2a", size = 67134 }
+sdist = { url = "https://files.pythonhosted.org/packages/34/42/bc712644bb597d02c0edfea6a10c409dc3b61f3dbce853f46fec5aed68db/funding_service_design_utils-6.0.1.tar.gz", hash = "sha256:5882f4f3c2db0bc254812ab4687d03972f24499392139c3676b60770f0397752", size = 67622 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/1b/4c3a8f89a3307d8381de2fae28d6322aea11b4a580cbdb3c7f48f6633cac/funding_service_design_utils-5.0.8-py3-none-any.whl", hash = "sha256:4582eef625c13c4059648b916040cf21e39e928c5e57326f8fc461e84eb34982", size = 81075 },
+    { url = "https://files.pythonhosted.org/packages/ad/df/54ad332f7a7ccd8995c9868a535a3a71ed4ee1e0ff3616681fad8008c853/funding_service_design_utils-6.0.1-py3-none-any.whl", hash = "sha256:dfe47bccb948cbd26884addd4ea5ef70d6804869541108725a53cc39904eaf87", size = 81295 },
 ]
 
 [[package]]


### PR DESCRIPTION
This is to pull in the ability to disable the config table from https://github.com/communitiesuk/funding-service-design-utils/pull/169.

v6 added a breaking change, but it was reverted in 6.0.1 so nothing to do.